### PR TITLE
fix(datasourceLoadError): load数据源的error不在向上层抛出

### DIFF
--- a/packages/vue-renderer/src/data-source/index.ts
+++ b/packages/vue-renderer/src/data-source/index.ts
@@ -114,7 +114,7 @@ export function createDataSourceItem(
       status.value = DataSourceStatus.Error;
       error.value = err;
       hooks.errorHandler(err);
-      throw err;
+      // throw err;
     }
   };
 


### PR DESCRIPTION
修复数据源load函数中，请求结果状态码为400以上抛出的RequestError在上层没有处理导致画布空白的bug。
## bug复现过程
1. 在画布上随便画几个组件
![image](https://github.com/KNXCloud/lowcode-engine-vue/assets/27946984/4f8036c9-8382-4e74-a412-aab489217483)
2. 在数据源面板中新建一个确保错误的请求
![image](https://github.com/KNXCloud/lowcode-engine-vue/assets/27946984/e6a009f5-877a-4b15-911e-9c823dcfb939)
3. 导致页面空白，控制台报错
![image](https://github.com/KNXCloud/lowcode-engine-vue/assets/27946984/c8a4795f-685f-47ad-bda7-1163541a6ae2)
