### PR TITLE
feat(appHelper.utils): VueRenderer支持appHelper中的utils功能

### DIFF
--- a/packages/vue-renderer/src/core/base.ts
+++ b/packages/vue-renderer/src/core/base.ts
@@ -59,6 +59,11 @@ export const rendererProps = {
     type: Object as PropType<SchemaParser>,
     required: true,
   },
+  /** 主要用于设置渲染模块的全局上下文，里面定义的内容可以在低代码中通过 this 来访问，比如 this.utils */
+  appHelper: {
+    type: Object as PropType<any>,
+    required: false,
+  },
 } as const;
 
 export type RendererProps = ExtractPropTypes<typeof rendererProps>;

--- a/packages/vue-renderer/src/core/use.ts
+++ b/packages/vue-renderer/src/core/use.ts
@@ -655,7 +655,12 @@ export function useRenderer(rendererProps: RendererProps, scope: RuntimeScope) {
 }
 
 export function useRootScope(rendererProps: RendererProps, setupConext: object) {
-  const { __schema: schema, __scope: extraScope, __parser: parser } = rendererProps;
+  const {
+    __schema: schema,
+    __scope: extraScope,
+    __parser: parser,
+    appHelper,
+  } = rendererProps;
 
   const {
     props: propsSchema,
@@ -688,6 +693,12 @@ export function useRootScope(rendererProps: RendererProps, setupConext: object) 
   if (methodsSchema) {
     const methods = parser.parseSchema(methodsSchema, scope);
     methods && addToScope(scope, AccessTypes.CONTEXT, methods);
+  }
+
+  // 处理appHelper中的utils
+  const utils = appHelper?.utils;
+  if (utils) {
+    addToScope(scope, AccessTypes.CONTEXT, { utils });
   }
 
   // 处理 state

--- a/packages/vue-renderer/src/renderer.ts
+++ b/packages/vue-renderer/src/renderer.ts
@@ -33,7 +33,10 @@ import {
   exportSchema,
   isBoolean,
 } from '@knxcloud/lowcode-utils';
-
+export type IRendererAppHelper = Partial<{
+  /** 全局公共函数 */
+  utils: Record<string, any>;
+}>;
 const vueRendererProps = {
   scope: Object as PropType<BlockScope>,
   schema: {
@@ -72,6 +75,11 @@ const vueRendererProps = {
     default: false,
   },
   requestHandlersMap: Object,
+  /** 主要用于设置渲染模块的全局上下文，里面定义的内容可以在低代码中通过 this 来访问，比如 this.utils */
+  appHelper: {
+    type: Object as PropType<IRendererAppHelper>,
+    required: false,
+  },
 } as const;
 
 type VueRendererProps = ExtractPublicPropTypes<typeof vueRendererProps>;
@@ -197,6 +205,7 @@ const VueRenderer = defineComponent({
               __thisRequiredInJSE: thisRequiredInJSE,
               __getNode: getNode,
               __triggerCompGetCtx: triggerCompGetCtx,
+              appHelper: props.appHelper,
             } as any,
             slots
           )


### PR DESCRIPTION
VueRenderer支持appHelper中的utils功能。可以在预览状态下通过appHelper传入第三方utils。参考https://lowcode-engine.cn/site/docs/guide/expand/runtime/renderer#apphelper